### PR TITLE
Sc-new-story/add-more-details-to-details-view

### DIFF
--- a/mediaflick/src/app/(organizer)/mediainfo/[id]/page.tsx
+++ b/mediaflick/src/app/(organizer)/mediainfo/[id]/page.tsx
@@ -58,7 +58,7 @@ export default function MediaInfoPage() {
         <div className="container mx-auto px-4 py-24">
           <MediaDetails mediaInfo={mediaInfo} />
           {mediaInfo.MediaType === MediaType.TvShows && (
-            <SeasonList tmdbId={mediaInfo.TmdbId} seasonCount={mediaInfo.SeasonCount} />
+            <SeasonList tmdbId={mediaInfo.TmdbId} mediaInfo={mediaInfo} />
           )}
         </div>
       </div>

--- a/mediaflick/src/components/media-info/media-details.tsx
+++ b/mediaflick/src/components/media-info/media-details.tsx
@@ -43,7 +43,22 @@ export function MediaDetails({ mediaInfo }: MediaDetailsProps) {
               ))}
             </div>
           )}
-
+          {mediaInfo.ImdbId && (
+            <div>
+              <h3 className="mb-2 text-xl font-semibold">IMDb ID:</h3>
+              <p className="text-default-500">
+                {mediaInfo.MediaType === MediaType.Movies ? (
+                  <a href={`https://debridmediamanager.com/movie/${mediaInfo.ImdbId}`} target="_blank" rel="noopener noreferrer">
+                    {mediaInfo.ImdbId}
+                  </a>
+                ) : (
+                  <a href={`https://debridmediamanager.com/show/${mediaInfo.ImdbId}/1`} target="_blank" rel="noopener noreferrer">
+                    {mediaInfo.ImdbId}
+                  </a>
+                )}
+              </p>
+            </div>
+          )}
           {mediaInfo.Overview && (
             <div>
               <h2 className="mb-2 text-xl font-semibold">Overview</h2>

--- a/mediaflick/src/components/media-info/season-list.tsx
+++ b/mediaflick/src/components/media-info/season-list.tsx
@@ -1,10 +1,10 @@
 import Image from "next/image"
 import { useEffect, useState } from "react"
 
-import { Accordion, AccordionItem, Card, CardBody, Spinner } from "@nextui-org/react"
+import { Accordion, AccordionItem, Button, Card, CardBody, Link, Spinner } from "@nextui-org/react"
 
 import { mediaApi } from "@/lib/api/endpoints"
-import type { SeasonInfo } from "@/lib/api/types"
+import type { MediaInfo, SeasonInfo } from "@/lib/api/types"
 
 // Cache for storing season data
 const seasonCache = new Map<string, { data: SeasonInfo; timestamp: number }>()
@@ -12,20 +12,20 @@ const CACHE_DURATION = 1000 * 30 // 30 seconds
 
 interface SeasonListProps {
   tmdbId: number
-  seasonCount?: number
+  mediaInfo: MediaInfo
 }
 
-export function SeasonList({ tmdbId, seasonCount = 0 }: SeasonListProps) {
+export function SeasonList({ tmdbId, mediaInfo }: SeasonListProps) {
   const [loading, setLoading] = useState(false)
   const [seasons, setSeasons] = useState<SeasonInfo[]>([])
 
   useEffect(() => {
     const loadSeasons = async () => {
-      if (!seasonCount) return
+      if (!mediaInfo.SeasonCount) return
 
       try {
         setLoading(true)
-        const seasonNumbers = Array.from({ length: seasonCount }, (_, i) => i + 1)
+        const seasonNumbers = Array.from({ length: mediaInfo.SeasonCount }, (_, i) => i + 1)
         const seasonMap = new Map<number, SeasonInfo>()
 
         // Process seasons in chunks to avoid overwhelming the API
@@ -79,7 +79,7 @@ export function SeasonList({ tmdbId, seasonCount = 0 }: SeasonListProps) {
     // Reset seasons when tmdbId or seasonCount changes
     setSeasons([])
     loadSeasons()
-  }, [seasonCount, tmdbId])
+  }, [mediaInfo.SeasonCount, tmdbId])
 
   if (loading && seasons.length === 0) {
     return (
@@ -130,6 +130,20 @@ export function SeasonList({ tmdbId, seasonCount = 0 }: SeasonListProps) {
                         <p className="line-clamp-3 text-small text-default-500 [text-shadow:0_1px_2px_rgba(0,0,0,0.8)]">
                           {season.Overview}
                         </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          variant="bordered"
+                          color="primary"
+                          size="sm"
+                          className="p-0"
+                          as={Link}
+                          href={`https://debridmediamanager.com/show/${mediaInfo.ImdbId}/${season.SeasonNumber}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          DMM
+                        </Button>
                       </div>
                     </div>
                   }

--- a/src/PlexLocalScan.Api/Controllers/MediaLookupController.cs
+++ b/src/PlexLocalScan.Api/Controllers/MediaLookupController.cs
@@ -4,7 +4,6 @@ using PlexLocalScan.Core.Series;
 using PlexLocalScan.Shared.Services;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace PlexLocalScan.Api.Controllers;
 


### PR DESCRIPTION
- Modified the SeasonList component to accept mediaInfo instead of seasonCount, enhancing data handling and reducing prop dependencies.
- Updated the logic to dynamically generate season numbers based on mediaInfo.SeasonCount.
- Added a button in the season details for direct access to the Debrid Media Manager, improving user navigation.

These changes aim to streamline the component's functionality and improve user experience in the MediaFlick application.