### PR TITLE
refactor: remove MapImageEndpoints from MediaLookupRouting

### DIFF
--- a/src/PlexLocalScan.Api/Routing/MediaLookupRouting.cs
+++ b/src/PlexLocalScan.Api/Routing/MediaLookupRouting.cs
@@ -18,7 +18,6 @@ internal static class MediaLookupRouting
 
         MapMovieEndpoints(group);
         MapTvShowEndpoints(group);
-        MapImageEndpoints(group);
     }
 
     private static void MapMovieEndpoints(RouteGroupBuilder group)
@@ -62,11 +61,4 @@ internal static class MediaLookupRouting
             .Produces<EpisodeInfo>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
     }
-
-    private static void MapImageEndpoints(RouteGroupBuilder group) => group.MapGet("images/{*path}", MediaLookupEndpoints.GetImageUrl)
-        .WithName("GetImageUrl")
-        .WithDescription("Gets the URL for an image by TMDb path and size")
-        .Produces<string>(StatusCodes.Status200OK)
-        .Produces(StatusCodes.Status400BadRequest)
-        .Produces(StatusCodes.Status404NotFound);
 }


### PR DESCRIPTION
- Eliminated the MapImageEndpoints method from MediaLookupRouting to streamline routing logic.
- This change simplifies the API structure by focusing on movie and TV show endpoints, enhancing maintainability.

These changes aim to improve the clarity and efficiency of the routing configuration in the PlexLocalScan.Api.